### PR TITLE
Require Node.js 12 and move to ESM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 16
           - 14
           - 12
-          - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/fixtures/filepath/1.js
+++ b/fixtures/filepath/1.js
@@ -1,2 +1,3 @@
-'use strict';
-require('./2')();
+import x from './2.js';
+
+x();

--- a/fixtures/filepath/2.js
+++ b/fixtures/filepath/2.js
@@ -1,4 +1,5 @@
-'use strict';
-module.exports = () => {
-	require('./3')(__filename);
-};
+import three from './3.js';
+
+export default function two() {
+	three(import.meta.url);
+}

--- a/fixtures/filepath/3.js
+++ b/fixtures/filepath/3.js
@@ -1,6 +1,5 @@
-'use strict';
-const parentModule = require('../..');
+import parentModule from '../../index.js';
 
-module.exports = filepath => {
+export default function three(filepath) {
 	console.log(parentModule(filepath));
-};
+}

--- a/fixtures/main/1.js
+++ b/fixtures/main/1.js
@@ -1,2 +1,3 @@
-'use strict';
-require('./2')();
+import two from './2.js';
+
+two();

--- a/fixtures/main/2.js
+++ b/fixtures/main/2.js
@@ -1,6 +1,5 @@
-'use strict';
-const parentModule = require('../..');
+import parentModule from '../../index.js';
 
-module.exports = () => {
+export default function two() {
 	console.log(parentModule());
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
-'use strict';
-const callsites = require('callsites');
+import callsites from 'callsites';
 
-module.exports = filePath => {
+export default function parentModule(filePath) {
 	const stacks = callsites();
 
 	if (!filePath) {
@@ -34,4 +33,4 @@ module.exports = filePath => {
 			return parentFilePath;
 		}
 	}
-};
+}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import parentModule = require('.');
+import parentModule from './index.js';
 
 expectType<string | undefined>(parentModule());
 expectType<string | undefined>(parentModule('foo'));

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "sindresorhus.com"
 	},
+	"type": "module",
 	"engines": {
-		"node": ">=8"
+		"node": ">=12"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -36,12 +37,12 @@
 		"file"
 	],
 	"dependencies": {
-		"callsites": "^3.1.0"
+		"callsites": "^4.0.0"
 	},
 	"devDependencies": {
-		"ava": "^1.4.1",
-		"execa": "^1.0.0",
-		"tsd": "^0.7.2",
-		"xo": "^0.24.0"
+		"ava": "^3.15.0",
+		"execa": "^5.1.1",
+		"tsd": "^0.17.0",
+		"xo": "^0.44.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,9 @@ $ npm install parent-module
 
 ```js
 // bar.js
-const parentModule = require('parent-module');
+import parentModule from 'parent-module';
 
-module.exports = () => {
+export default function bar() {
 	console.log(parentModule());
 	//=> '/Users/sindresorhus/dev/unicorn/foo.js'
 };
@@ -24,7 +24,7 @@ module.exports = () => {
 
 ```js
 // foo.js
-const bar = require('./bar');
+import bar from './bar.js';
 
 bar();
 ```
@@ -49,9 +49,9 @@ Useful if you want it to work [multiple module levels down](fixtures/filepath).
 Combine it with [`read-pkg-up`](https://github.com/sindresorhus/read-pkg-up) to read the package.json of the parent module.
 
 ```js
-const path = require('path');
-const readPkgUp = require('read-pkg-up');
-const parentModule = require('parent-module');
+import path from 'node:path';
+import readPkgUp from 'read-pkg-up';
+import parentModule from 'parent-module';
 
 console.log(readPkgUp.sync({cwd: path.dirname(parentModule())}).pkg);
 //=> {name: 'chalk', version: '1.0.0', …}

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import test from 'ava';
 import execa from 'execa';
 


### PR DESCRIPTION
Require Node.js 12 and move to ESM

- [x] updated Readme example
- [x] updated package dependencies
- [x] set package type=module and min node engine to >=12
- [x] changed workflow to test 12,14,16
- [x] fixed new lint rules
- did I forget something? 